### PR TITLE
Add a setImmediate based .load() function to monomers for simpler API and recursion.

### DIFF
--- a/lib/monomers.js
+++ b/lib/monomers.js
@@ -10,6 +10,7 @@
 'use strict';
 // jshint -W079
 var Promise = global.Promise || require('es6-promise').Promise;
+require("setimmediate");
 // jshint +W079
 
 var dom5 = require('dom5');
@@ -69,19 +70,13 @@ var EMPTY_METADATA = {elements: [], modules: []};
 /**
 * A database of polymer elements and select js modules defined in HTML.
 *
-* @param  {string} htmlImport The raw text to process.
 * @param  {boolean} attachAST  If true, attach a parse5 compliant AST.
-* @param  {string} href       The URL of the element.
 * @param  {FileLoader=} loader An optional `FileLoader` used to load external
 *                              resources.
 */
-var Monomers = function Monomers(htmlImport,
-                                 attachAST,
-                                 href,
+var Monomers = function Monomers(attachAST,
                                  loader) {
-  this.htmlImport = htmlImport;
   this.attachAST = attachAST;
-  this.href = href;
   this.loader = loader;
 
   this.elements = {};
@@ -92,8 +87,20 @@ var Monomers = function Monomers(htmlImport,
    * @type {Object}
    */
   this.html = {};
-  this.root = this._parseHTML(htmlImport, href);
 };
+
+Monomers.prototype.load = function load(href) {
+  if (href in this.html) {
+    return Promise.resolve(this.html[href]);
+  }
+  return this.loader.request(href).then(function(content) {
+    return new Promise(function(resolve, reject) {
+      setImmediate(function() {
+        resolve(this._parseHTML(content, href));
+      }.bind(this));
+    }.bind(this));
+  }.bind(this));
+}
 
 /**
  * Returns an HTMLMonomer representing the provided document.
@@ -129,8 +136,8 @@ Monomers.prototype._parseHTML = function _parseHTML(htmlImport,
       if (linkurl) {
         var resolvedUrl = url.resolve(href, linkurl);
         depHrefs.push(resolvedUrl);
-        var dep = this.loader.request(resolvedUrl).then(function(content) {
-          return this._parseHTML(content, resolvedUrl).depsLoaded;
+        var dep = this.load(resolvedUrl).then(function(monomer) {
+          return monomer.depsLoaded;
         }.bind(this));
         depsLoaded.push(dep);
       }
@@ -200,12 +207,17 @@ Monomers.prototype._processScript = function _processScript(script, href) {
  * Returns a promise that resolves to a POJO representation of the import
  * tree.
  */
-Monomers.prototype.metadataTree = function metadataTree() {
-  return this._metadataTree(this.root, {});
+Monomers.prototype.metadataTree = function metadataTree(href) {
+  return this.load(href).then(function(monomer){
+    return this._metadataTree(monomer);
+  }.bind(this));
 };
 
 Monomers.prototype._metadataTree = function _metadataTree(htmlMonomer,
                                                           loadedHrefs) {
+  if (loadedHrefs === undefined) {
+    loadedHrefs = {};
+  }
   return htmlMonomer.metadataLoaded.then(function(metadata) {
     return htmlMonomer.depsLoaded.then(function(hrefs) {
       var depMetadata = [];

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "parse5": "^1.3.2",
     "request": "^2.53.0",
     "send": "^0.10.1",
+    "setimmediate": "^1.0.2",
     "substratum": "^0.1.1"
   }
 }


### PR DESCRIPTION
Adds .load() for help recursing inside _parseHTML and to provide a cleaner API for using monomers.

By breaking up the recursion inside .load(), all parse work is moved to the end of the current task using a setImmediate polyfill.