### PR TITLE
Change to espree for parsing.

### DIFF
--- a/lib/ast-utils/js-parse.js
+++ b/lib/ast-utils/js-parse.js
@@ -11,7 +11,7 @@
 * Finds and annotates the Polymer() and modulate() calls in javascript.
 */
 'use strict';
-var esprima = require('esprima');
+var espree = require('espree');
 var estraverse = require('estraverse');
 
 var modulateFinder = require('./modulate-finder');
@@ -43,7 +43,7 @@ function traverse(visitorRegistries) {
 }
 
 var jsParse = function jsParse(jsString, attachAST) {
-  var script = esprima.parse(jsString,
+  var script = espree.parse(jsString,
                              {attachComment: true,
                               comment: true,
                               loc: true});

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dom5": "PolymerLabs/dom5",
     "es6-map": "^0.1.1",
     "es6-promise": "^2.0.1",
-    "esprima": "^2.0.0",
+    "espree": "^1.12.2",
     "estraverse": "^1.9.1",
     "gulp": "^3.8.11",
     "parse5": "^1.3.2",


### PR DESCRIPTION
Parsing tests continue to pass.

The failure in safari has changed, but it seems to be core-asset related. I'll resolve in another PR.